### PR TITLE
Add comment preview functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# comment-preview
+# WordPress Comment Preview
+
 Plugin for WordPress Comment Preview

--- a/assets/js/comment-preview.js
+++ b/assets/js/comment-preview.js
@@ -1,0 +1,90 @@
+( function ( data ) {
+	const previewButton = document.getElementById( 'preview' );
+	const anonymousCheckBox = document.getElementById( 'anonymous-override' );
+	const previewWrapper = document.getElementById( 'preview-wrapper' );
+	const template = document.getElementById( 'preview-template' );
+
+	document.getElementById( 'cancel-comment-reply-link' ).addEventListener( 'click', clearPreview );
+	document.querySelectorAll( '.comment-reply-link' ).forEach( ( replyButton ) => {
+		replyButton.addEventListener( 'click', clearPreview );
+	} )
+
+	previewButton.addEventListener( 'click', () => {
+
+		// Disable the preview button while generating the preview.
+		previewButton.disabled = true;
+
+		// Collect the data to pass along for generating a comment preview.
+		const commentData = {
+			comment: document.getElementById( 'comment' ).value,
+			format: document.querySelector( '[name="wp_comment_format"]:checked' ).value,
+		};
+
+		// Add anonymous submission data if applicable.
+		if ( anonymousCheckBox && anonymousCheckBox.checked ) {
+			commentData.anonymous = true;
+		}
+
+		// Make the request.
+		fetch( data.apiURL + 'preview', {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json, text/plain, */*',
+				'Content-Type': 'application/json',
+				'X-WP-Nonce': data.nonce, // Required for any authenticated requests.
+			},
+			body: JSON.stringify( commentData ),
+		} )
+			.then( response => response.json() )
+			.then( data => displayPreview( data ) );
+	} );
+
+	/**
+	 * Clear out the preview wrapper when a reply or cancel link is clicked.
+	 */
+	function clearPreview() {
+		previewWrapper.innerHTML = '';
+	}
+
+	/**
+	 * Fill in the preview template with the response data.
+	 *
+	 * @param {Object} data Response data.
+	 */
+	function displayPreview( data ) {
+
+		const preview = template.content.cloneNode( true );
+
+		// Fill in the pieces.
+		preview.querySelector( '.avatar' ).src = data.gravatar;
+		preview.querySelector( '.comment-author .fn' ).innerText = data.author;
+		preview.querySelector( 'time' ).innerText = data.date;
+		preview.querySelector( '.comment-content' ).innerHTML = data.comment;
+
+		// Clear out any previous previews before appending the current one.
+		previewWrapper.innerHTML = '';
+		previewWrapper.append( preview );
+
+		// Add the badge class if appropriate - `preview` is a DocumentFragment,
+		// so it doesn't have a classList property to manipulate directly.
+		if ( data.class ) {
+			previewWrapper.querySelector( '.comment' ).classList.add( data.class );
+		}
+
+		// Account for the WP Admin bar when determining scroll coordinates.
+		let offset = ( document.body.classList.contains( 'admin-bar' ) )
+			? document.getElementById( 'wpadminbar' ).offsetHeight
+			: 0;
+
+		// Scroll to the generated preview.
+		window.scrollTo(
+			{
+				top: previewWrapper.getBoundingClientRect().top + window.pageYOffset - offset,
+				behavior: 'smooth'
+			}
+		);
+
+		// Re-enable the preview button to allow further previews.
+		previewButton.disabled = false;
+	}
+} )( commentPreviewData ); /* global commentPreviewData */

--- a/assets/js/comment-preview.js
+++ b/assets/js/comment-preview.js
@@ -1,6 +1,5 @@
 ( function ( data ) {
 	const previewButton = document.getElementById( 'preview' );
-	const anonymousCheckBox = document.getElementById( 'anonymous-override' );
 	const previewWrapper = document.getElementById( 'preview-wrapper' );
 	const template = document.getElementById( 'preview-template' );
 
@@ -20,9 +19,10 @@
 			format: document.querySelector( '[name="wp_comment_format"]:checked' ).value,
 		};
 
-		// Add anonymous submission data if applicable.
-		if ( anonymousCheckBox && anonymousCheckBox.checked ) {
-			commentData.anonymous = true;
+		let author = document.getElementById( 'author' );
+
+		if ( 'undefined' !== typeof author && null !== author ) {
+			commentData.author = author.value;
 		}
 
 		// Make the request.

--- a/inc/classes/class-comment-preview.php
+++ b/inc/classes/class-comment-preview.php
@@ -116,9 +116,10 @@ class Comment_Preview {
 	 * Append a button to allow commenters to preview their comment.
 	 *
 	 * @param string $submit_button HTML to output for the submit button.
+	 *
 	 * @return string Modified HTML
 	 */
-	public function append_preview_button( string $submit_button = '' ) {
+	public function append_preview_button( $submit_button = '' ) {
 
 		$preview_button = '<input name="preview" type="button" id="preview" class="submit" value="Preview">';
 
@@ -152,13 +153,21 @@ class Comment_Preview {
 
 		$response = array();
 
-		$response['author'] = 'Anonymous';
-
-		if ( ! empty( $request['author'] ) && ! isset( $request['anonymous'] ) ) {
+		if ( ! empty( $request['author'] ) ) {
 			$response['author'] = esc_html( $request['author'] );
 		}
 
-		$user_id = ( 'Anonymous' === $response['author'] ) ? 0 : get_current_user_id();
+		$user_id = ( ( is_user_logged_in() ) ? get_current_user_id() : 0 );
+
+		if ( ! empty( $user_id ) ) {
+
+			$user = get_userdata( $user_id );
+
+			if ( $user ) {
+
+				$response['author'] = $user->data->display_name;
+			}
+		}
 
 		$response['gravatar'] = get_avatar_url( $user_id, array( 'size' => 50 ) );
 

--- a/inc/classes/class-comment-preview.php
+++ b/inc/classes/class-comment-preview.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Class to manage functions for comment preview.
+ */
+
+namespace CommentPreview\Inc;
+
+/**
+ * Class for comment preview functionality.
+ *
+ * @package CommentPreview\Inc
+ */
+class Comment_Preview {
+
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+
+		$this->_setup_hooks();
+	}
+
+	/**
+	 * Initialize actions and filters.
+	 */
+	protected function _setup_hooks() {
+
+		add_filter( 'comment_form_submit_button', array( $this, 'append_preview_button' ) );
+
+		add_filter( 'comment_form_field_comment', array( $this, 'append_markdown_option' ), 20 );
+
+		add_filter( 'comment_form_fields', array( $this, 'comment_form_fields' ), 20 );
+
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+
+		add_action( 'rest_api_init', array( $this, 'register_rest_route' ) );
+	}
+
+	/**
+	 * Add custom markup in comment form.
+	 *
+	 * @param array $comment_fields Comment fields.
+	 *
+	 * @return mixed
+	 */
+	public function comment_form_fields( array $comment_fields = array() ) {
+
+		ob_start();
+
+		// Get template file output.
+		include WP_COMMENT_PREVIEW_PATH . 'templates/comment-preview.php';
+
+		// Save output and stop output buffering.
+		$field = ob_get_clean();
+
+		if ( ! empty( $field ) ) {
+
+			$comment_fields['comment'] = '<div id="preview-wrapper"></div>' . $comment_fields['comment'];
+
+			$comment_fields['comment'] .= $field;
+		}
+
+		return $comment_fields;
+	}
+
+	/**
+	 * Enqueue JavaScript for handling comment previews.
+	 */
+	public function enqueue_scripts() {
+
+		$allowed_post_types = apply_filters( 'wp_comment_preview_post_types', array( 'post' ) );
+
+		if ( is_singular( $allowed_post_types ) ) {
+
+			wp_register_script(
+				'wp-comment-preview',
+				WP_COMMENT_PREVIEW_URL . '/assets/js/comment-preview.js',
+				array(),
+				'1.0.0',
+				true
+			);
+
+			wp_localize_script(
+				'wp-comment-preview',
+				'commentPreviewData',
+				array(
+					'apiURL' => get_rest_url( null, 'wp_comment_preview/v1/' ),
+					'nonce'  => wp_create_nonce( 'wp_rest' ),
+				)
+			);
+
+			wp_enqueue_script( 'wp-comment-preview' );
+
+		}
+	}
+
+	/**
+	 * Append radio buttons to allow a commenter to format their comment in
+	 * either markdown or plain text.
+	 *
+	 * @param string $field HTML to output for the comment field.
+	 * @return string Modified HTML.
+	 */
+	public function append_markdown_option( $field ) {
+
+		$append_field  = '<div class="comment-form-markdown">';
+		$append_field .= '<input checked="checked" type="radio" id="format-markdown-radio" name="wp_comment_format" value="markdown">';
+		$append_field .= '<label for="format-markdown-radio">Use <a href="https://commonmark.org/help/">markdown</a>.</label> ';
+		$append_field .= '<input type="radio" id="format-text-radio" name="wp_comment_format" value="text">';
+		$append_field .= '<label for="format-text-radio">Use plain text.</label></div>';
+
+		return $field . $append_field;
+	}
+
+	/**
+	 * Append a button to allow commenters to preview their comment.
+	 *
+	 * @param string $submit_button HTML to output for the submit button.
+	 * @return string Modified HTML
+	 */
+	public function append_preview_button( string $submit_button = '' ) {
+
+		$preview_button = '<input name="preview" type="button" id="preview" class="submit" value="Preview">';
+
+		return $submit_button . $preview_button;
+	}
+
+	/**
+	 * Register the route for generating comment previews.
+	 */
+	public function register_rest_route() {
+
+		register_rest_route(
+			'wp_comment_preview/v1',
+			'preview',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'generate_preview' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * Processes a comment for previewing.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 *
+	 * @return \WP_REST_Response|array Response object.
+	 */
+	public function generate_preview( $request ) {
+
+		$response = array();
+
+		$response['author'] = 'Anonymous';
+
+		if ( ! empty( $request['author'] ) && ! isset( $request['anonymous'] ) ) {
+			$response['author'] = esc_html( $request['author'] );
+		}
+
+		$user_id = ( 'Anonymous' === $response['author'] ) ? 0 : get_current_user_id();
+
+		$response['gravatar'] = get_avatar_url( $user_id, array( 'size' => 50 ) );
+
+		$response['date'] = current_time( get_option( 'date_format' ) . ' \a\t ' . get_option( 'time_format' ) );
+
+		$response['subject'] = ( isset( $request['subject'] ) ) ? esc_html( $request['subject'] ) : '';
+
+		if ( isset( $request['comment'] ) && isset( $request['format'] ) ) {
+			if ( 'text' === $request['format'] ) {
+				$comment = wp_kses_data( $request['comment'] );
+			} else {
+				$comment = apply_filters( 'pre_comment_content', $request['comment'] );
+			}
+		} else {
+			$comment = '';
+		}
+
+		$response['comment'] = wpautop( $comment );
+
+		return $response;
+	}
+
+}

--- a/templates/comment-preview.php
+++ b/templates/comment-preview.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Template for Previewing Comment.
+ */
+
+?>
+
+<template id="preview-template">
+
+	<div class="comment">
+
+		<article class="comment-body">
+
+			<header class="comment-meta">
+
+				<div class="comment-author vcard">
+
+					<img alt="" src="" class="avatar" height="50" width="50">
+
+					<span class="fn"></span>
+
+					<span class="screen-reader-text says">says:</span>
+
+				</div>
+
+				<div class="comment-metadata">
+					<a href="#">
+						<time datetime=""></time>
+					</a>
+				</div>
+
+				<h1 class="comment-title"></h1>
+
+			</header>
+
+			<div class="comment-content entry-content"></div>
+
+		</article>
+
+	</div>
+
+</template>

--- a/wp-comment-preview.php
+++ b/wp-comment-preview.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin Name:     WP Comment Preview
+ * Plugin URI:      https://github.com/vishalkakadiya
+ * Description:     Allow to display comment preview.
+ * Author:          Vishal Kakadiya
+ * Author URI:      https://github.com/vishalkakadiya
+ * Text Domain:     comment-preview
+ * Domain Path:     /languages
+ * Version:         0.1.0
+ *
+ * @package         Comment_Preview
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+define( 'WP_COMMENT_PREVIEW_URL', plugin_dir_url( __FILE__ ) );
+define( 'WP_COMMENT_PREVIEW_PATH', plugin_dir_path( __FILE__ ) );
+
+require_once __DIR__ . '/inc/classes/class-comment-preview.php';
+
+new \CommentPreview\Inc\Comment_Preview();


### PR DESCRIPTION
- Add endpoint to format comment as markdown.
- Add a preview button beside the comment submit button.
- Add ajax call to preview comment with author's gravatar, so it will preview just like actual comment.